### PR TITLE
jtj-MS294-support-vlm-in-autokernel

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -14,6 +14,12 @@ Usage:
   uv run bench.py --quick                # skip stages 3-5, bench only large size
   uv run bench.py --profile              # emit torch profiler trace
   uv run bench.py --sizes large          # benchmark only 'large' size
+  uv run bench.py --dtype bfloat16       # benchmark with bf16 as the primary dtype
+
+kernel.py may override the built-in benchmark config by declaring any of
+TEST_SIZES, EDGE_SIZES, TOLERANCES, TEST_DTYPES, FLOPS_FN, BYTES_FN --
+extract.py writes these into every kernel it generates so that a kernel taken
+from a real model is benchmarked at that model's shapes and dtype.
 """
 
 from __future__ import annotations
@@ -598,6 +604,160 @@ KERNEL_CONFIGS: Dict[str, Dict[str, Any]] = {
 
 
 # =========================================================================
+# 4b. CONFIG RESOLUTION -- overlay per-kernel overrides from kernel.py
+# =========================================================================
+
+_DTYPE_BY_NAME: Dict[str, torch.dtype] = {
+    "float16": torch.float16, "fp16": torch.float16, "half": torch.float16,
+    "bfloat16": torch.bfloat16, "bf16": torch.bfloat16,
+    "float32": torch.float32, "fp32": torch.float32, "float": torch.float32,
+}
+
+_DEFAULT_TOLERANCES: Dict[torch.dtype, Dict[str, float]] = {
+    torch.float16:  {"atol": 1e-2, "rtol": 1e-2},
+    torch.bfloat16: {"atol": 2e-2, "rtol": 2e-2},
+    torch.float32:  {"atol": 1e-4, "rtol": 1e-4},
+}
+
+# Labels marking the primary benchmark size, in preference order. The built-in
+# configs use 'large'; kernels written by extract.py use 'model_primary'.
+_PRIMARY_SIZE_LABELS = ("model_primary", "large")
+
+
+def _coerce_dtype(value: Any) -> torch.dtype:
+    """Accept a torch.dtype or a string name like 'bfloat16' / 'torch.bfloat16'."""
+    if isinstance(value, torch.dtype):
+        return value
+    if isinstance(value, str):
+        key = value.lower().strip().replace("torch.", "")
+        if key in _DTYPE_BY_NAME:
+            return _DTYPE_BY_NAME[key]
+    raise ValueError(
+        f"Unrecognized dtype {value!r}. Supported: {sorted(set(_DTYPE_BY_NAME))}"
+    )
+
+
+def pick_primary_size(sizes: List[Tuple[str, Dict[str, int]]]) -> Tuple[str, Dict[str, int]]:
+    """Return the (label, size) pair to report as the primary benchmark result."""
+    for preferred in _PRIMARY_SIZE_LABELS:
+        for label, sz in sizes:
+            if label == preferred:
+                return label, sz
+    return sizes[-1]
+
+
+def pick_smallest_size(sizes: List[Tuple[str, Dict[str, int]]]) -> Tuple[str, Dict[str, int]]:
+    """Return the (label, size) pair with the fewest elements, for the smoke test.
+
+    The built-in configs already list their smallest size first, so this picks
+    the same entry they always did. Extracted kernels list the model shape
+    first, and smoke-testing on a full model shape is needlessly slow."""
+    def _volume(item: Tuple[str, Dict[str, int]]) -> int:
+        vol = 1
+        for v in item[1].values():
+            if isinstance(v, int) and v > 0:
+                vol *= v
+        return vol
+    return min(sizes, key=_volume)
+
+
+def _coerce_sizes(raw: Any, attr: str) -> List[Tuple[str, Dict[str, int]]]:
+    """Validate a TEST_SIZES/EDGE_SIZES override into [(label, {dim: int})]."""
+    if not isinstance(raw, (list, tuple)) or not raw:
+        raise ValueError(f"{attr} must be a non-empty list of (label, size_dict) pairs")
+    sizes = []
+    for item in raw:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            raise ValueError(
+                f"{attr} entries must be (label, size_dict) pairs, got {item!r}"
+            )
+        label, sz = item
+        if not isinstance(sz, dict) or not sz:
+            raise ValueError(f"{attr} entry '{label}' must be a non-empty dict")
+        if not all(isinstance(v, int) and v > 0 for v in sz.values()):
+            raise ValueError(
+                f"{attr} entry '{label}' must map dimension names to positive ints"
+            )
+        sizes.append((str(label), dict(sz)))
+    return sizes
+
+
+def resolve_config(
+    kernel_type: str,
+    kernel_module: Any,
+    dtype_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the benchmark config for this run.
+
+    Starts from the built-in KERNEL_CONFIGS entry, then overlays whatever the
+    kernel file declares: TEST_SIZES, EDGE_SIZES, TOLERANCES, TEST_DTYPES,
+    FLOPS_FN, BYTES_FN. extract.py writes those into every generated kernel, so
+    a kernel pulled out of a real model is benchmarked at that model's shapes
+    and dtype instead of the generic defaults. A hand-written kernel.py that
+    declares none of them gets the built-in config unchanged.
+
+    --dtype, if given, moves that dtype to the front of test_dtypes, which is
+    what the performance run and stages 3-5 measure with.
+    """
+    config = dict(KERNEL_CONFIGS[kernel_type])
+    overrides: List[str] = []
+
+    raw_sizes = getattr(kernel_module, "TEST_SIZES", None)
+    if raw_sizes is not None:
+        config["test_sizes"] = _coerce_sizes(raw_sizes, "TEST_SIZES")
+        overrides.append(f"test_sizes({len(config['test_sizes'])})")
+
+    raw_edge = getattr(kernel_module, "EDGE_SIZES", None)
+    if raw_edge is not None:
+        config["edge_sizes"] = _coerce_sizes(raw_edge, "EDGE_SIZES")
+        overrides.append("edge_sizes")
+
+    raw_tols = getattr(kernel_module, "TOLERANCES", None)
+    if raw_tols is not None:
+        if not isinstance(raw_tols, dict) or not raw_tols:
+            raise ValueError("TOLERANCES must be a non-empty dict keyed by dtype")
+        config["tolerances"] = {_coerce_dtype(k): dict(v) for k, v in raw_tols.items()}
+        overrides.append("tolerances")
+
+    raw_dtypes = getattr(kernel_module, "TEST_DTYPES", None)
+    if raw_dtypes is not None:
+        if not isinstance(raw_dtypes, (list, tuple)) or not raw_dtypes:
+            raise ValueError("TEST_DTYPES must be a non-empty list of dtypes")
+        config["test_dtypes"] = [_coerce_dtype(d) for d in raw_dtypes]
+        overrides.append("test_dtypes")
+
+    flops_fn = getattr(kernel_module, "FLOPS_FN", None)
+    if callable(flops_fn):
+        config["flops_fn"] = flops_fn
+        overrides.append("flops_fn")
+
+    bytes_fn = getattr(kernel_module, "BYTES_FN", None)
+    if callable(bytes_fn):
+        # kernel.py declares BYTES_FN(size, dt_bytes); configs want (size, dtype).
+        config["bytes_fn"] = lambda s, dt, _fn=bytes_fn: _fn(s, _dtype_bytes(dt))
+        overrides.append("bytes_fn")
+
+    if dtype_override is not None:
+        primary = _coerce_dtype(dtype_override)
+        config["test_dtypes"] = [primary] + [
+            d for d in config["test_dtypes"] if d != primary
+        ]
+        overrides.append(f"primary_dtype={primary}")
+
+    # Every dtype under test needs a tolerance entry.
+    tols = dict(config["tolerances"])
+    for dt in config["test_dtypes"]:
+        if dt not in tols:
+            tols[dt] = _DEFAULT_TOLERANCES.get(dt, {"atol": 1e-2, "rtol": 1e-2})
+    config["tolerances"] = tols
+
+    if overrides:
+        print(f"config_overrides: {', '.join(overrides)}")
+
+    return config
+
+
+# =========================================================================
 # 5. CORRECTNESS TESTING (5 stages)
 # =========================================================================
 
@@ -663,7 +823,7 @@ def run_correctness(kernel_fn: Callable, config: dict, quick: bool = False) -> d
     # ------------------------------------------------------------------
     print("\n--- Stage 1: Smoke Test ---")
     try:
-        tiny_label, tiny_size = sizes[0]
+        tiny_label, tiny_size = pick_smallest_size(sizes)
         # Use first dtype
         dtype0 = dtypes[0]
         inputs = gen_fn(tiny_size, dtype0, device, seed=42)
@@ -1021,24 +1181,11 @@ def run_performance(kernel_fn: Callable, config: dict, gpu: GPUSpec,
                 bench_sizes = [(label, sz)]
                 break
         if not bench_sizes:
-            # If filter doesn't match, use 'large' or the biggest available
-            for label, sz in sizes:
-                if label == "large":
-                    bench_sizes = [(label, sz)]
-                    break
-            if not bench_sizes:
-                bench_sizes = [sizes[-1]]
+            # If filter doesn't match, fall back to the primary size
+            bench_sizes = [pick_primary_size(sizes)]
 
-    # Find the primary benchmark size (large or biggest)
-    primary_label = None
-    primary_size = None
-    for label, sz in sizes:
-        if label == "large":
-            primary_label = label
-            primary_size = sz
-            break
-    if primary_size is None:
-        primary_label, primary_size = sizes[-1]
+    # Find the primary benchmark size (model_primary, large, or biggest)
+    primary_label, primary_size = pick_primary_size(sizes)
 
     dtype = dtypes[0]  # primary dtype for benchmarking
 
@@ -1203,6 +1350,9 @@ def main():
                         help="Quick mode: skip correctness stages 3-5, bench only large size")
     parser.add_argument("--profile", action="store_true",
                         help="Enable torch profiler trace")
+    parser.add_argument("--dtype", type=str, default=None,
+                        help="Primary dtype to benchmark with, e.g. bfloat16 "
+                             "(default: read TEST_DTYPES from kernel.py, else float16)")
     args = parser.parse_args()
 
     # ------------------------------------------------------------------
@@ -1260,7 +1410,13 @@ def main():
         print(f"throughput_tflops: 0.000")
         sys.exit(1)
 
-    config = KERNEL_CONFIGS[kernel_type]
+    try:
+        config = resolve_config(kernel_type, kernel_module, args.dtype)
+    except ValueError as e:
+        print(f"\nERROR: Invalid benchmark config: {e}")
+        print(f"\ncorrectness: FAIL")
+        print(f"throughput_tflops: 0.000")
+        sys.exit(1)
 
     # ------------------------------------------------------------------
     # GPU Detection
@@ -1302,16 +1458,7 @@ def main():
     # Performance
     # ------------------------------------------------------------------
     # Determine primary size info for the header
-    _perf_sizes = config["test_sizes"]
-    _perf_primary_label = None
-    _perf_primary_size = None
-    for _pl, _ps in _perf_sizes:
-        if _pl == "large":
-            _perf_primary_label = _pl
-            _perf_primary_size = _ps
-            break
-    if _perf_primary_size is None:
-        _perf_primary_label, _perf_primary_size = _perf_sizes[-1]
+    _perf_primary_label, _perf_primary_size = pick_primary_size(config["test_sizes"])
     _perf_dtype = config["test_dtypes"][0]
     _size_params = ", ".join(f"{k}={v}" for k, v in _perf_primary_size.items())
     print(f"\n=== PERFORMANCE ({_perf_primary_label}: {_size_params}, dtype={_perf_dtype}) ===")

--- a/extract.py
+++ b/extract.py
@@ -8,6 +8,7 @@ Usage:
     uv run extract.py --kernel-type matmul     # extract only matmul kernels
     uv run extract.py --report path/to/report.json
     uv run extract.py --backend cuda           # use CUDA C++ starter kernels instead of Triton
+    uv run extract.py --dtype bfloat16         # override the profiled dtype
 """
 
 from __future__ import annotations
@@ -129,6 +130,35 @@ TOLERANCES_MAP: Dict[str, Dict[str, Dict[str, float]]] = {
     },
 }
 
+# Dtypes swept per op_type, mirroring bench.py's built-in test_dtypes.
+# The profiled model's dtype is moved to the front of this list, since bench.py
+# measures performance with test_dtypes[0].
+TEST_DTYPES_MAP: Dict[str, List[str]] = {
+    "matmul":           ["float16", "bfloat16", "float32"],
+    "softmax":          ["float16", "bfloat16", "float32"],
+    "layernorm":        ["float16", "bfloat16", "float32"],
+    "flash_attention":  ["float16", "bfloat16"],
+    "fused_mlp":        ["float16", "bfloat16", "float32"],
+    "cross_entropy":    ["float16", "bfloat16", "float32"],
+    "rotary_embedding": ["float16", "bfloat16", "float32"],
+    "rmsnorm":          ["float16", "bfloat16"],
+    "reduce":           ["float16", "bfloat16"],
+}
+
+# Canonical dtype names, so --dtype bf16 and --dtype bfloat16 agree.
+DTYPE_ALIASES: Dict[str, str] = {
+    "float16": "float16", "fp16": "float16", "half": "float16",
+    "bfloat16": "bfloat16", "bf16": "bfloat16",
+    "float32": "float32", "fp32": "float32", "float": "float32",
+}
+
+# Fallback tolerances when a model's dtype has no entry in TOLERANCES_MAP.
+DEFAULT_TOLERANCE_BY_DTYPE: Dict[str, Dict[str, float]] = {
+    "float16":  {"atol": 1e-2, "rtol": 1e-2},
+    "bfloat16": {"atol": 2e-2, "rtol": 2e-2},
+    "float32":  {"atol": 1e-4, "rtol": 1e-4},
+}
+
 # FLOPS formulas as source strings, per op_type
 FLOPS_FN_SRC: Dict[str, str] = {
     "matmul":           'return 2 * s["M"] * s["N"] * s["K"]',
@@ -243,6 +273,23 @@ def get_default_shape(op_type: str) -> Dict[str, int]:
 # Kernel file generation
 # ---------------------------------------------------------------------------
 
+def normalize_dtype(dtype_str: Optional[str]) -> str:
+    """Canonicalize a dtype name from the profile report. Defaults to float16."""
+    if not dtype_str:
+        return "float16"
+    return DTYPE_ALIASES.get(str(dtype_str).lower().strip(), "float16")
+
+
+def order_test_dtypes(op_type: str, model_dtype: str) -> List[str]:
+    """Return the dtype sweep for an op with the model's dtype first.
+
+    bench.py benchmarks with test_dtypes[0], so a bf16 model must not be
+    measured in fp16.
+    """
+    candidates = list(TEST_DTYPES_MAP.get(op_type, ["float16", "bfloat16"]))
+    return [model_dtype] + [d for d in candidates if d != model_dtype]
+
+
 def read_starter_kernel(op_type: str, backend: str = "triton") -> Optional[str]:
     """Read the starter kernel file. Returns None if not found.
 
@@ -296,6 +343,7 @@ def generate_kernel_file(
     gpu_time_ms: float,
     starter_code: str,
     backend: str = "triton",
+    model_dtype: str = "float16",
 ) -> str:
     """Generate the complete kernel file content for extraction."""
 
@@ -306,11 +354,15 @@ def generate_kernel_file(
     half_display = shape_to_display(half_shape)
     double_display = shape_to_display(double_shape)
 
-    tolerances = TOLERANCES_MAP.get(op_type, {
-        "float16":  {"atol": 1e-2, "rtol": 1e-2},
-        "bfloat16": {"atol": 2e-2, "rtol": 2e-2},
-        "float32":  {"atol": 1e-4, "rtol": 1e-4},
-    })
+    test_dtypes = order_test_dtypes(op_type, model_dtype)
+
+    tolerances = dict(TOLERANCES_MAP.get(op_type, DEFAULT_TOLERANCE_BY_DTYPE))
+    # Every dtype in the sweep needs a tolerance entry.
+    for dt in test_dtypes:
+        if dt not in tolerances:
+            tolerances[dt] = DEFAULT_TOLERANCE_BY_DTYPE.get(
+                dt, {"atol": 1e-2, "rtol": 1e-2}
+            )
 
     flops_fn_body = FLOPS_FN_SRC.get(op_type, 'return 0')
     bytes_fn_body = BYTES_FN_SRC.get(op_type, 'return 0')
@@ -327,6 +379,7 @@ def generate_kernel_file(
     lines.append(f"Op type: {op_type}")
     lines.append(f"Rank: {rank} ({pct_total}% of GPU time)")
     lines.append(f"Model shape: {shape_display}")
+    lines.append(f"Model dtype: {model_dtype}")
     lines.append(f"")
     lines.append(f"This kernel was extracted from profiling {model_name}.")
     lines.append(f"The agent optimizes this to maximize throughput at the model-specific shapes.")
@@ -345,13 +398,20 @@ def generate_kernel_file(
     lines.append("")
 
     # Benchmark config
-    lines.append("# Benchmark config (self-describing -- bench.py can load this dynamically)")
+    lines.append("# Benchmark config -- bench.py loads these and overlays them onto its")
+    lines.append("# built-in config for this kernel type, so the model's own shapes and")
+    lines.append("# dtype are what get benchmarked.")
     lines.append("TEST_SIZES = [")
     lines.append(f'    ("model_primary", {repr(model_shape)}),')
     lines.append(f"    # Also test nearby sizes for robustness")
     lines.append(f'    ("model_half", {repr(half_shape)}),')
     lines.append(f'    ("model_double", {repr(double_shape)}),')
     lines.append("]")
+    lines.append("")
+
+    # Dtypes (model dtype first -- bench.py measures with TEST_DTYPES[0])
+    lines.append("# Model dtype first: bench.py measures performance with TEST_DTYPES[0].")
+    lines.append(f"TEST_DTYPES = {repr(test_dtypes)}")
     lines.append("")
 
     # Tolerances
@@ -464,6 +524,7 @@ def extract_kernels(
     top_n: Optional[int] = None,
     kernel_type_filter: Optional[str] = None,
     backend: str = "triton",
+    dtype_override: Optional[str] = None,
 ) -> None:
     """Main extraction pipeline."""
 
@@ -481,6 +542,10 @@ def extract_kernels(
 
     # -- Get model name --
     model_name = report.get("model_name", report.get("model", "unknown model"))
+
+    # -- Get model dtype (bench.py measures with TEST_DTYPES[0]) --
+    model_dtype = normalize_dtype(dtype_override or report.get("dtype"))
+    print(f"Model dtype: {model_dtype}")
 
     # -- Get supported kernels --
     supported = get_supported_kernels(report)
@@ -552,6 +617,7 @@ def extract_kernels(
             gpu_time_ms=gpu_time_ms,
             starter_code=starter_code,
             backend=backend,
+            model_dtype=model_dtype,
         )
 
         # Write to workspace
@@ -633,6 +699,14 @@ def main() -> None:
         default="triton",
         help="Backend for starter kernels: 'triton' (default) or 'cuda' (native CUDA C++)",
     )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default=None,
+        help="Override the dtype recorded in the profile report (e.g. bfloat16). "
+             "This becomes TEST_DTYPES[0] in the generated kernels, which is what "
+             "bench.py measures with.",
+    )
 
     args = parser.parse_args()
 
@@ -641,6 +715,7 @@ def main() -> None:
         top_n=args.top,
         kernel_type_filter=args.kernel_type,
         backend=args.backend,
+        dtype_override=args.dtype,
     )
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+# Install uv (if you don't have it)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone and setup
+uv sync
+
+# One-time setup: test data + baselines
+uv run prepare.py
+
+# Install claude
+curl -fsSL https://claude.ai/install.sh | bash

--- a/verify.py
+++ b/verify.py
@@ -218,6 +218,17 @@ def generate_sample_input(
 
 def infer_input_type(model: nn.Module) -> str:
     """Try to determine if the model expects integer token IDs or float tensors."""
+    # The forward signature is the most reliable signal. HuggingFace
+    # *ForCausalLM / *ForConditionalGeneration wrappers take input_ids, but
+    # their children are (model, lm_head) -- so the child scan below would hit
+    # lm_head and wrongly answer "float".
+    try:
+        sig = inspect.signature(model.forward)
+        if "input_ids" in sig.parameters:
+            return "token_ids"
+    except (ValueError, TypeError):
+        pass
+
     # Check if model has an embedding layer as the first module
     for name, child in model.named_children():
         if isinstance(child, nn.Embedding):
@@ -225,6 +236,20 @@ def infer_input_type(model: nn.Module) -> str:
         if isinstance(child, (nn.Linear, nn.Conv2d)):
             return "float"
     return "float"
+
+
+def infer_vocab_size(model: nn.Module, default: int = 32000) -> int:
+    """Find the model's vocab size so generated token IDs are always in range."""
+    config = getattr(model, "config", None)
+    vocab = getattr(config, "vocab_size", None)
+    if isinstance(vocab, int) and vocab > 0:
+        return vocab
+
+    for module in model.modules():
+        if isinstance(module, nn.Embedding) and module.num_embeddings > 0:
+            return module.num_embeddings
+
+    return default
 
 
 def make_model_input(
@@ -240,7 +265,8 @@ def make_model_input(
         # Language model: expects integer input_ids
         dims = [int(d.strip()) for d in input_shape.split(",")]
         torch.manual_seed(42)
-        input_ids = torch.randint(0, 32000, dims, device=device, dtype=torch.long)
+        vocab_size = infer_vocab_size(model)
+        input_ids = torch.randint(0, vocab_size, dims, device=device, dtype=torch.long)
 
         # Check if model accepts input_ids keyword
         sig = inspect.signature(model.forward)


### PR DESCRIPTION
Benchmark extracted kernels at the model's real shapes and dtype

bench.py resolved every config from hardcoded KERNEL_CONFIGS, ignoring the TEST_SIZES/TOLERANCES extract.py writes into each generated kernel, and always measured with test_dtypes[0] == float16. Overlay the kernel file's declarations onto the built-in config, emit TEST_DTYPES with the profiled dtype first, and add --dtype to both tools.

Also fix verify.py's input inference, which returned "float" for any model whose first Linear child is lm_head -- including the repo's own models/gpt2.py.